### PR TITLE
Fix incorrect contact email address in API metadata

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -181,7 +181,7 @@ Contact: contact@slmar.co
         },
         contact={
             "name": "WINDMAR Support",
-            "url": "https://windmar.io",
+            "url": "https://slmar.co",
             "email": "contact@slmar.co",
         },
     )


### PR DESCRIPTION
Replace support@windmar.io with contact@slmar.co 