### PR TITLE
Fix baseline SOG profile showing uniform speed

### DIFF
--- a/frontend/components/ProfileCharts.tsx
+++ b/frontend/components/ProfileCharts.tsx
@@ -246,20 +246,21 @@ export default function ProfileCharts({ baseline, optimizations, departureTime }
     [departureMs, maxEtaMs, baselineProfile, optProfiles, visible],
   );
 
-  // Auto-scale SOG Y-axis
+  // Auto-scale SOG Y-axis — fixed to min/max across ALL solutions (not just visible)
+  // so toggling routes doesn't shift the axis and differences are always readable.
   const sogDomain = useMemo<[number, number]>(() => {
     let min = Infinity, max = -Infinity;
-    for (const row of sogData) {
-      for (const [k, v] of Object.entries(row)) {
-        if (k === 'time' || v === undefined) continue;
-        const n = Number(v);
-        if (n < min) min = n;
-        if (n > max) max = n;
+    const scan = (pts: TimePoint[]) => {
+      for (const p of pts) {
+        if (p.sog < min) min = p.sog;
+        if (p.sog > max) max = p.sog;
       }
-    }
+    };
+    scan(baselineProfile);
+    for (const profile of optProfiles.values()) scan(profile);
     if (!isFinite(min)) return [0, 15];
     return [Math.max(0, Math.floor((min - 0.5) * 2) / 2), Math.ceil((max + 0.5) * 2) / 2];
-  }, [sogData]);
+  }, [baselineProfile, optProfiles]);
 
   // X-axis tick formatter — choose ~8 evenly spaced ticks
   const timeDomain = useMemo<[number, number]>(() => [departureMs, maxEtaMs], [departureMs, maxEtaMs]);

--- a/src/optimization/route_optimizer.py
+++ b/src/optimization/route_optimizer.py
@@ -204,6 +204,9 @@ class RouteOptimizer(BaseOptimizer):
         # Weather provider function (set before optimization)
         self.weather_provider: Optional[Callable] = None
 
+        # Time-value penalty (computed per voyage in optimize_route)
+        self._lambda_time: float = 0.0
+
     # ------------------------------------------------------------------
     # Waypoint interpolation for baseline route evaluation
     # ------------------------------------------------------------------
@@ -233,9 +236,6 @@ class RouteOptimizer(BaseOptimizer):
                 )
             result.append((lat2, lon2))
         return result
-
-        # Time-value penalty (computed per voyage in optimize_route)
-        self._lambda_time: float = 0.0
 
     def _prepare_search_params(self, is_laden: bool, calm_speed_kts: float) -> None:
         """Pre-compute vessel constants for A* inner loop (avoids per-cell lookups)."""

--- a/src/optimization/route_optimizer.py
+++ b/src/optimization/route_optimizer.py
@@ -204,6 +204,36 @@ class RouteOptimizer(BaseOptimizer):
         # Weather provider function (set before optimization)
         self.weather_provider: Optional[Callable] = None
 
+    # ------------------------------------------------------------------
+    # Waypoint interpolation for baseline route evaluation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _interpolate_waypoints(
+        waypoints: List[Tuple[float, float]],
+        max_leg_nm: float = 30.0,
+    ) -> List[Tuple[float, float]]:
+        """Subdivide long legs so each segment is at most *max_leg_nm*.
+
+        Ensures weather is sampled at multiple points along the route
+        rather than a single midpoint per leg.
+        """
+        from src.optimization.base_optimizer import BaseOptimizer
+
+        result = [waypoints[0]]
+        for i in range(len(waypoints) - 1):
+            lat1, lon1 = waypoints[i]
+            lat2, lon2 = waypoints[i + 1]
+            dist = BaseOptimizer.haversine(lat1, lon1, lat2, lon2)
+            n_seg = max(1, int(math.ceil(dist / max_leg_nm)))
+            for j in range(1, n_seg):
+                frac = j / n_seg
+                result.append(
+                    (lat1 + frac * (lat2 - lat1), lon1 + frac * (lon2 - lon1))
+                )
+            result.append((lat2, lon2))
+        return result
+
         # Time-value penalty (computed per voyage in optimize_route)
         self._lambda_time: float = 0.0
 
@@ -427,12 +457,15 @@ class RouteOptimizer(BaseOptimizer):
         waypoints[0] = origin
         waypoints[-1] = destination
 
-        # "Direct" route = user's original waypoints if provided, else straight line
+        # "Direct" route = user's original waypoints if provided, else straight line.
+        # Interpolate so each segment is ~30 NM — ensures per-leg weather sampling
+        # captures spatial variation (currents, wind, waves) instead of one midpoint.
         direct_wps = (
             list(route_waypoints)
             if route_waypoints and len(route_waypoints) > 2
             else [origin, destination]
         )
+        direct_wps = self._interpolate_waypoints(direct_wps)
 
         # Calculate direct route for comparison (constant speed to match voyage calculator)
         direct_fuel, direct_time, direct_distance, _, _, _ = (
@@ -726,12 +759,13 @@ class RouteOptimizer(BaseOptimizer):
         # Restore lambda for stats calculation
         self._lambda_time = base_fuel_rate * self.TIME_PENALTY_WEIGHT
 
-        # Calculate direct route for comparison
+        # Calculate direct route for comparison (interpolated for weather sampling)
         direct_wps = (
             list(route_waypoints)
             if route_waypoints and len(route_waypoints) > 2
             else [origin, destination]
         )
+        direct_wps = self._interpolate_waypoints(direct_wps)
         direct_fuel, direct_time, direct_distance, _, _, _ = (
             self._calculate_route_stats(
                 direct_wps,


### PR DESCRIPTION
Interpolate direct-route waypoints into ~30 NM segments so weather (currents, wind, waves) is sampled at multiple points along the route instead of a single midpoint per leg.

Also fix SOG chart Y-axis to use min/max across all solutions so toggling route visibility does not shift the scale.